### PR TITLE
added support for https with vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ pids
 *.seed
 *.pid.lock
 *.eslintcache
+*.pem
 
 # NodeJS #
 ##########

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This is a [github template](https://github.blog/2019-06-06-generate-new-reposito
 -   [✔️] JEST Test preconfigured
 -   [✔️] Full async code
 -   [✔️] Github and Vscode dotfiles preconfigured
+-   [✔️] HTTP/HTTPS support
 -   [✔️] Translations i18n: 🇬🇧 🇮🇹 🇵🇱 (Help me ❤️)
 
 ### 🔖 TODO
@@ -60,8 +61,8 @@ This is a [github template](https://github.blog/2019-06-06-generate-new-reposito
 
 1. Clone this repository or download [nightly](https://github.com/ptkdev-boilerplate/svelte-kit-ssr-boilerplate/archive/nightly.zip), [beta](https://github.com/ptkdev-boilerplate/svelte-kit-ssr-boilerplate/archive/beta.zip) or [stable](https://github.com/ptkdev-boilerplate/svelte-kit-ssr-boilerplate/archive/main.zip).
 2. Run `npm run init`
-3. Run `npm run dev`
-4. Run `http://localhost:5000`
+3. Run `npm run dev` or `npm run dev-https` (this assumes you have [mkcert](https://github.com/FiloSottile/mkcert))
+4. Run `http://localhost:5000` or `https://localhost:5000`
 
 ## 📚 Documentation
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"setup": "ts-node --skip-project scripts/setup.ts && ts-node --skip-project scripts/changelog.ts && npm run pre-commit",
 		"start": "svelte-kit preview -p 5000",
 		"dev": "svelte-kit dev -p 5000",
+		"dev-https": "mkcert localhost && svelte-kit dev -p 5000 -H",
 		"build": "svelte-kit build",
 		"release": "npm run build && ttsc --declaration --emitDeclarationOnly",
 		"test": "jest app",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,7 @@
 import preprocess from "svelte-preprocess";
 import adapter from "@sveltejs/adapter-node";
+import * as fs from "fs";
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://github.com/sveltejs/svelte-preprocess
@@ -24,5 +26,17 @@ const config = {
 		}
 	}
 };
+
+// Add certificate if it's generated
+if (fs.existsSync("localhost-key.pem") && fs.existsSync("localhost.pem")) {
+	config.kit.vite = {
+		server: {
+			https: {
+				key: fs.readFileSync("localhost-key.pem"),
+				cert: fs.readFileSync("localhost.pem")
+			}
+		}
+	};
+}
 
 export default config;


### PR DESCRIPTION
Added support for https with vite. 
Command available through `npm run dev-https` that will create certificate files in same directory and will be read through `fs` if they exists.